### PR TITLE
Enhance prompt by using search-list for Response Mode

### DIFF
--- a/src/adapters/file-upload.test.ts
+++ b/src/adapters/file-upload.test.ts
@@ -342,10 +342,9 @@ describe('FileUpload Adapter', () => {
 
         expect(cliux.inquire).toHaveBeenCalledWith(
           expect.objectContaining({
-            type: 'list',
+            type: 'search-list',
             name: 'responseMode',
-            message: 'Choose a response mode',
-            default: 'buffered',
+            message: 'Response mode',
             choices: [
               { name: 'Buffered', value: 'buffered' },
               { name: 'Streaming', value: 'streaming' },
@@ -487,10 +486,9 @@ describe('FileUpload Adapter', () => {
       expect(serverCommandCalls.length).toBe(0);
       expect(cliux.inquire).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'list',
+          type: 'search-list',
           name: 'responseMode',
-          message: 'Choose a response mode',
-          default: 'buffered',
+          message: 'Response mode',
           choices: [
             { name: 'Buffered', value: 'buffered' },
             { name: 'Streaming', value: 'streaming' },
@@ -639,7 +637,7 @@ describe('FileUpload Adapter', () => {
         (call) => call[0]?.name === 'responseMode',
       );
 
-      expect(responseModeCall[0].type).toBe('list');
+      expect(responseModeCall[0].type).toBe('search-list');
       expect(responseModeCall[0].choices).toEqual([
         { name: 'Buffered', value: 'buffered' },
         { name: 'Streaming', value: 'streaming' },

--- a/src/adapters/file-upload.ts
+++ b/src/adapters/file-upload.ts
@@ -251,10 +251,9 @@ export default class FileUpload extends BaseClass {
     }
     if (!responseMode) {
       const selectedResponseMode = (await cliux.inquire({
-        type: 'list',
+        type: 'search-list',
         name: 'responseMode',
-        message: 'Choose a response mode',
-        default: 'buffered',
+        message: 'Response mode',
         choices: [
           { name: 'Buffered', value: 'buffered' },
           { name: 'Streaming', value: 'streaming' },

--- a/src/adapters/github.test.ts
+++ b/src/adapters/github.test.ts
@@ -597,10 +597,9 @@ describe('GitHub Adapter', () => {
 
         expect(ux.inquire).toHaveBeenCalledWith(
           expect.objectContaining({
-            type: 'list',
+            type: 'search-list',
             name: 'responseMode',
-            message: 'Choose a response mode',
-            default: 'buffered',
+            message: 'Response mode',
             choices: [
               { name: 'Buffered', value: 'buffered' },
               { name: 'Streaming', value: 'streaming' },
@@ -717,10 +716,9 @@ describe('GitHub Adapter', () => {
       expect(serverCommandCalls.length).toBe(0);
       expect(ux.inquire).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'list',
+          type: 'search-list',
           name: 'responseMode',
-          message: 'Choose a response mode',
-          default: 'buffered',
+          message: 'Response mode',
           choices: [
             { name: 'Buffered', value: 'buffered' },
             { name: 'Streaming', value: 'streaming' },
@@ -833,7 +831,7 @@ describe('GitHub Adapter', () => {
         (call) => call[0]?.name === 'responseMode',
       );
 
-      expect(responseModeCall[0].type).toBe('list');
+      expect(responseModeCall[0].type).toBe('search-list');
       expect(responseModeCall[0].choices).toEqual([
         { name: 'Buffered', value: 'buffered' },
         { name: 'Streaming', value: 'streaming' },

--- a/src/adapters/github.ts
+++ b/src/adapters/github.ts
@@ -239,10 +239,9 @@ export default class GitHub extends BaseClass {
     }
     if (!responseMode) {
       const selectedResponseMode = (await ux.inquire({
-        type: 'list',
+        type: 'search-list',
         name: 'responseMode',
-        message: 'Choose a response mode',
-        default: 'buffered',
+        message: 'Response mode',
         choices: [
           { name: 'Buffered', value: 'buffered' },
           { name: 'Streaming', value: 'streaming' },


### PR DESCRIPTION
feat: use search-list prompt for response mode instead of list