### PR TITLE
fix: ensure Apollo client is rebuilt after configuration update in rollback command (csdx launch: rollback)

### DIFF
--- a/src/commands/launch/rollback.ts
+++ b/src/commands/launch/rollback.ts
@@ -54,6 +54,8 @@ export default class Rollback extends BaseCommand<typeof Rollback> {
     if (!this.flags.environment) {
       await this.getConfig();
     }
+    
+    await this.prepareApiClients();
 
     if (!this.sharedConfig.currentConfig?.uid) {
       await selectOrg({


### PR DESCRIPTION
## Summary
- Fixes `launch.PROJECT.NOT_FOUND` errors when running `csdx launch:rollback` with no flags against a project that already has a resolved `cs-launch.json`.
- Root cause: `Rollback.init()` builds the Apollo client via `prepareApiClients()` before `run()` calls `getConfig()`, so the client is constructed with no `x-project-uid`/`organization_uid` headers. `run()` only rebuilds the client inside the `!currentConfig?.uid` branch (interactive org/project selection) — which is skipped whenever `getConfig()` already resolved a `uid` from disk. Every subsequent query (including the `Environments` query the rollback flow depends on) then goes out headerless, and `EnvironmentsAuthGuard` on the server can't find any project to match.
- Fix: rebuild the Apollo client unconditionally right after `getConfig()` in `run()`, so headers always reflect whatever project/org context was just resolved from `cs-launch.json` (or flags), before any query fires.

## Root cause detail
- Works today when `-e/--environment` is passed (skips `getConfig()`, so `uid` stays unset → falls into the org/project-selection branch, which happens to rebuild the client) or on a brand-new project before `cs-launch.json` exists (same reason). Looked intermittent, but is fully deterministic on those two conditions.
- Fails today on the common case: an existing project, no flags — `getConfig()` resolves `uid`, the rebuild branch is skipped, and the stale headerless client from `init()` is used for the rest of the command.

## Change
`src/commands/launch/rollback.ts` — added one line in `run()`:
```ts
if (!this.flags.environment) {
  await this.getConfig();
}
await this.prepareApiClients(); // rebuild client with resolved project/org headers
