### PR TITLE
chore: pin brace-expansion and fast-uri via npm overrides to resolve Snyk vulnerabilities (+Claude)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -9,7 +9,7 @@ fileignoreconfig:
 - filename: test/unit/commands/rollback.test.ts
   checksum: d1f931f2d9a397131409399ad6463653e28b5a2224e870b641d9ba57c4418f18
 - filename: package-lock.json
-  checksum: c94ce0fbbbedcbad4dceef8168971831ed82aad85824db579f2497dcd49aecab
+  checksum: 77fee207c89799a9d2b4e0b1713db9f8770304c3c3ecfc2afabf514f17fbfe8d
 - filename: src/adapters/github.test.ts
   checksum: b3d3d3a3c14adde103152d2ac4e1c4b7121a5f7533a87c3cc600f6d25fb59d1b
 - filename: src/adapters/file-upload.test.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -5971,15 +5971,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -8667,9 +8667,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -8778,9 +8778,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -12985,9 +12985,9 @@
       "license": "MIT"
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -16773,6 +16773,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,17 @@
       "ajv": "^6.12.6"
     },
     "qs": "^6.15.2",
-    "tmp": "^0.2.4"
+    "tmp": "^0.2.4",
+    "fast-uri": "^3.1.5",
+    "minimatch@10.2.5": {
+      "brace-expansion": "^5.0.9"
+    },
+    "minimatch@9.0.9": {
+      "brace-expansion": "^2.1.4"
+    },
+    "minimatch@5.1.9": {
+      "brace-expansion": "^2.1.4"
+    }
   },
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## What

Resolves 4 High-severity Snyk findings (23 vulnerable paths) via scoped npm `overrides` — **no major-version bumps** to `@oclif/core` or `@contentstack/cli-utilities`, per explicit request.

| Finding | Path | Before → After | Fix |
|---|---|---|---|
| SNYK-JS-BRACEEXPANSION-18313044 | `@oclif/core > minimatch@10.2.5 > brace-expansion` | 5.0.7 → **5.0.9** | override scoped to `minimatch@10.2.5` |
| SNYK-JS-BRACEEXPANSION-18512280 | `@oclif/core > ejs > jake > filelist > minimatch@5.1.9`, `mocha > minimatch@9.0.9` | 2.1.2 → **2.1.4** | override scoped to `minimatch@9.0.9` / `minimatch@5.1.9` |
| SNYK-JS-FASTURI-18021349 | `@contentstack/cli-utilities@1.18.5 > conf > ajv > fast-uri` | 3.1.3 → **3.1.5** | flat override |
| SNYK-JS-FASTURI-18506908 | same path as above | 3.1.3 → **3.1.5** | same override |

```json
"minimatch@10.2.5": { "brace-expansion": "^5.0.9" },
"minimatch@9.0.9":  { "brace-expansion": "^2.1.4" },
"minimatch@5.1.9":  { "brace-expansion": "^2.1.4" }
```

**Why scoped per-parent instead of a flat `brace-expansion` override:** the dependency tree carries three concurrent `brace-expansion` major lines at once (v1.x under old `minimatch@3.1.5` via eslint tooling, v2.x under `minimatch@5.1.9`/`9.0.9`, v5.x under `minimatch@10.2.5`). A flat override would force one version onto all of them and risk an API break in whichever majors don't expect it. Scoping by `<parent>@<version>` patches only the two genuinely vulnerable installed instances, in place, within their own major line. The pre-existing `brace-expansion@1.1.16` (eslint tooling) line was left untouched — Snyk never flagged it.

Also bumped `fast-uri` (single instance in the tree) via a flat override since there's no ambiguity there.

## Also included

- `.talismanrc`: updated the `package-lock.json` checksum entry. This repo's pre-commit Talisman hook pins an expected checksum for `package-lock.json` (its normal `sha512-...` integrity hashes otherwise look like base64 secrets to the scanner); any lockfile content change requires updating this entry. Not a security-relevant change.

## Tests

- `npm install` — clean
- `npm run build` — passes
- `npm test` — 129/129 Jest tests pass. The mocha suite reports 18 "failing"/early-cutoff entries with no printed stack traces — verified via `git stash` that this is **pre-existing** and identical on the unmodified baseline, unrelated to this change.
- `snyk test` re-scan — **0 vulnerable paths** (was 4 issues / 23 paths)

<img width="1288" height="656" alt="image" src="https://github.com/user-attachments/assets/ce3921e8-60eb-414c-a1bd-70cd77f163b2" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)